### PR TITLE
Move plugin index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,5 +19,7 @@ exclude:
   - Gemfile*
   - Rakefile
   - README.md
+  - CONTRIBUTING.md
+  - History.markdown
   - spec
   - script

--- a/plugins.html
+++ b/plugins.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Plugins Index
-permalink: /index/
+permalink: /plugins/
 ---
 
 <ul>


### PR DESCRIPTION
As long as our plugins are all in `/plugins/`, the index of all plugins should be at `/plugins/`
