### PR TITLE
Fix title of overview page

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
   <meta charset="UTF-8">
-  <title>{{ page.title }} &mdash; {{ site.title }}</title>
+  <title>{% if page.title %}{{ page.title }} &mdash; {% endif %}{{ site.title }}</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.baseurl }}/feed.xml" />
   <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
The overview page has no `page.title` and does not need the `&mdash;`