### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ jekyllrb.com/plugins/
 
 Plugins discovery for Jekyll, built with Jekyll – A proposal.
 
-[![Build Status](https://travis-ci.org/jekyll/plugins.svg?branch=gh-pages)](https://travis-ci.org/jekyll/plugins)
+[![Build Status](https://travis-ci.org/jekyll/plugins.svg?branch=master)](https://travis-ci.org/jekyll/plugins)
 
 # NOTE: This is just a proposal and does not represent any functionality of Jekyll at present.
 


### PR DESCRIPTION
Since we are deploying from the `master` branch instead of `gh-pages`, the build status badge needs to be updated. 