### PR TITLE
Update links to repository

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,11 +8,7 @@ layout: default
       <div class="unit whole">
         <article>
           <div class="improve right hide-on-mobiles">
-            {% if page.relative_path %}
-            <a href="{{ site.repository }}/edit/gh-pages/{{ page.relative_path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
-            {% else %}
-            <a href="{{ site.repository }}/edit/gh-pages/{{ page.path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
-            {% endif %}
+            <a href="{{ site.repository }}/edit/master/{{ page.relative_path | default: page.path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
           </div>
           <h1>{{ page.title }}</h1>
           {{ content }}

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ overview: true
       <p>
         Submit a pull request with the required data and
       </p>
-      <a href="{{ site.repository }}/blob/gh-pages/CONTRIBUTING.md" class="">How to Contribute &rarr;</a>
+      <a href="{{ site.repository }}/blob/master/CONTRIBUTING.md" class="">How to Contribute &rarr;</a>
     </div>
     <div class="clear"></div>
   </div>


### PR DESCRIPTION
When I deleted the `gh-pages` branch, I caused many links on the site to 404.

They should have been pointing to the `master` branch anyway.

#20