### PR TITLE
Use URL of plugin rather than our site

### DIFF
--- a/_includes/plugin-copy-and-paste-installation.html
+++ b/_includes/plugin-copy-and-paste-installation.html
@@ -1,5 +1,5 @@
 <p>
-  To install, you must copy the necessary files from <a href="{{ site.repository }}">the repository</a>
+  To install, you must copy the necessary files from <a href="{{ page.repository }}">the repository</a>
   to your Jekyll site. Further installation instructions are available in the repository's
   README.
 </p>


### PR DESCRIPTION
For instructions on how to copy-paste a plugin into a site's `_plugins/`, we were just linking to the repository of _this site_ rather than the repository of the plugin.

Oops 😶