### PR TITLE
Check that gems exist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "gems"
 gem "github-pages"
 gem "rspec"
 gem "html-proofer"

--- a/_plugins/jekyll_oembed.markdown
+++ b/_plugins/jekyll_oembed.markdown
@@ -1,5 +1,5 @@
 ---
-title: jekyll_oembed
+title: jekyll-oembed
 description: Jekyll plugin to embed objects with the help of oEmbed. Simple liquid tag
 author: stereobooster
 git: git@github.com:stereobooster/jekyll_oembed.git

--- a/spec/plugins_spec.rb
+++ b/spec/plugins_spec.rb
@@ -8,9 +8,9 @@ required_fields = %w{
   title description author git repository
 }
 
-describe("plugin manifests") do
-  Dir["_plugins/*"].each do |plugin|
-    plugin_info = SafeYAML.load_file(plugin)
+Dir["_plugins/*"].each do |plugin|
+  plugin_info = SafeYAML.load_file(plugin)
+  describe(plugin) do
 
     context File.basename(plugin, ".*") do
       required_fields.each do |field|
@@ -22,6 +22,12 @@ describe("plugin manifests") do
 
       it "complies with the accepted types" do
         expect(PLUGIN_TYPES).to include(plugin_info["type"])
+      end
+
+      if plugin_info["type"].nil?
+        it "is a gem" do
+          expect(plugin_info["title"]).to be_avaliable_on_rubygems
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,23 @@
+require "gems"
+require "rspec/expectations"
 require "safe_yaml"
+
+RSpec::Matchers.define :be_avaliable_on_rubygems do
+  match do |actual|
+    begin
+      Gems.info actual
+      true
+    rescue
+      false
+    end
+  end
+  description do
+    "be a gem avaliable on RubyGems.org"
+  end
+  failure_message do |actual|
+    %{could not find "#{actual}" on RubyGems.org}
+  end
+end
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true


### PR DESCRIPTION
If something claims to be a :gem:Gem, we should check that it is actually listed on RubyGems.org.

In writing this test, I already found one plugin that had the wrong title, so the installation instructions would not have worked. Fixed the title, and the test passes :+1: