### PR TITLE
Add 15 Jekyll plugins

### DIFF
--- a/_plugins/jekyll-better-related.md
+++ b/_plugins/jekyll-better-related.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-better-related
+description: >
+  An improved related posts plugin for Jekyll that uses tag-based and content-based
+  filtering to suggest more relevant related posts. Provides better post discovery
+  and improved site navigation.
+author: jchance
+git: git@github.com:jchance/jekyll-better-related.git
+repository: https://github.com/jchance/jekyll-better-related
+category: generator
+---

--- a/_plugins/jekyll-bunny.md
+++ b/_plugins/jekyll-bunny.md
@@ -1,0 +1,10 @@
+---
+title: jekyll-bunny
+description: >
+  A Jekyll plugin that provides a Liquid tag for embedding videos hosted on Bunny CDN
+  in blog posts and pages. Supports customizable player settings and quality options.
+author: jchance
+git: git@github.com:jchance/jekyll-bunny.git
+repository: https://github.com/jchance/jekyll-bunny
+category: tag
+---

--- a/_plugins/jekyll-callout.md
+++ b/_plugins/jekyll-callout.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-callout
+description: >
+  A Jekyll plugin that provides Liquid tags for creating styled callout boxes
+  for alerts, notes, warnings, and informational content in blog posts and pages.
+  Includes predefined styles with customization options.
+author: jchance
+git: git@github.com:jchance/jekyll-callout.git
+repository: https://github.com/jchance/jekyll-callout
+category: tag
+---

--- a/_plugins/jekyll-keepachangelog.md
+++ b/_plugins/jekyll-keepachangelog.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-keepachangelog
+description: >
+  A Jekyll plugin that automatically generates Jekyll pages from CHANGELOG.md files
+  following the Keep a Changelog format. Displays version history and release notes
+  as part of your site during the build process.
+author: jchance
+git: git@github.com:jchance/jekyll-keepachangelog.git
+repository: https://github.com/jchance/jekyll-keepachangelog
+category: generator
+---

--- a/_plugins/jekyll-livid.md
+++ b/_plugins/jekyll-livid.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-livid
+description: >
+  A Jekyll plugin that provides a simple Liquid tag for embedding Livid videos
+  in blog posts and pages. Supports advanced embedding parameters for customization
+  of video playback and display settings.
+author: jchance
+git: git@github.com:jchance/jekyll-livid.git
+repository: https://github.com/jchance/jekyll-livid
+category: tag
+---

--- a/_plugins/jekyll-llms-generator.md
+++ b/_plugins/jekyll-llms-generator.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-llms-generator
+description: >
+  A Jekyll plugin that automatically generates llms.txt files during the build
+  process to enable LLM discovery and indexing of your site's content.
+  Follows the emerging llms.txt specification for AI/LLM indexing.
+author: jchance
+git: git@github.com:jchance/jekyll-llms-generator.git
+repository: https://github.com/jchance/jekyll-llms-generator
+category: generator
+---

--- a/_plugins/jekyll-map.md
+++ b/_plugins/jekyll-map.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-map
+description: >
+  A Jekyll plugin that provides a Liquid tag for embedding interactive maps
+  from various providers including Google Maps and other mapping services
+  in blog posts and pages.
+author: jchance
+git: git@github.com:jchance/jekyll-map.git
+repository: https://github.com/jchance/jekyll-map
+category: tag
+---

--- a/_plugins/jekyll-mux.md
+++ b/_plugins/jekyll-mux.md
@@ -1,0 +1,10 @@
+---
+title: jekyll-mux
+description: >
+  A Jekyll plugin that provides a Liquid tag for embedding videos hosted on Mux
+  in blog posts and pages. Supports advanced video player configuration and analytics.
+author: jchance
+git: git@github.com:jchance/jekyll-mux.git
+repository: https://github.com/jchance/jekyll-mux
+category: tag
+---

--- a/_plugins/jekyll-opengraph-image.md
+++ b/_plugins/jekyll-opengraph-image.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-opengraph-image
+description: >
+  A Jekyll plugin that automatically generates Open Graph images for blog posts
+  during the build process. Creates eye-catching preview images for social media
+  sharing without manual design work.
+author: jchance
+git: git@github.com:jchance/jekyll-opengraph-image.git
+repository: https://github.com/jchance/jekyll-opengraph-image
+category: generator
+---

--- a/_plugins/jekyll-smart-reading-time.md
+++ b/_plugins/jekyll-smart-reading-time.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-smart-reading-time
+description: >
+  A Jekyll plugin that intelligently calculates reading time estimates for posts
+  based on content analysis, taking into account code blocks, images, and other
+  non-text content for more accurate time predictions.
+author: jchance
+git: git@github.com:jchance/jekyll-smart-reading-time.git
+repository: https://github.com/jchance/jekyll-smart-reading-time
+category: filter
+---

--- a/_plugins/jekyll-social-share.md
+++ b/_plugins/jekyll-social-share.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-social-share
+description: >
+  A Jekyll plugin that adds social media share buttons to blog posts with
+  customizable styling. Supports multiple social networks with brand-standard
+  colors and hover effects.
+author: jchance
+git: git@github.com:jchance/jekyll-social-share.git
+repository: https://github.com/jchance/jekyll-social-share
+category: tag
+---

--- a/_plugins/jekyll-streetview.md
+++ b/_plugins/jekyll-streetview.md
@@ -1,0 +1,10 @@
+---
+title: jekyll-streetview
+description: >
+  A Jekyll plugin that provides a Liquid tag for embedding Google Street View
+  panoramas in blog posts and pages with customizable viewing angles and zoom levels.
+author: jchance
+git: git@github.com:jchance/jekyll-streetview.git
+repository: https://github.com/jchance/jekyll-streetview
+category: tag
+---

--- a/_plugins/jekyll-structured-content.md
+++ b/_plugins/jekyll-structured-content.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-structured-content
+description: >
+  A Jekyll plugin that enables creating structured, reusable content blocks
+  with custom Liquid tags. Promotes DRY principles and consistency across
+  blog posts and pages.
+author: jchance
+git: git@github.com:jchance/jekyll-structured-content.git
+repository: https://github.com/jchance/jekyll-structured-content
+category: tag
+---

--- a/_plugins/jekyll-webmentions-static.md
+++ b/_plugins/jekyll-webmentions-static.md
@@ -1,0 +1,11 @@
+---
+title: jekyll-webmentions-static
+description: >
+  A Jekyll plugin that fetches and displays webmentions for blog posts during
+  the static build process. Enables participation in the webmention ecosystem
+  without requiring dynamic server-side code.
+author: jchance
+git: git@github.com:jchance/jekyll-webmentions-static.git
+repository: https://github.com/jchance/jekyll-webmentions-static
+category: generator
+---


### PR DESCRIPTION
Adding 15 new Jekyll plugins:

- jekyll-livid
- jekyll-bunny
- jekyll-mux
- jekyll-callout
- jekyll-map
- jekyll-streetview
- jekyll-structured-content
- jekyll-llms-generator
- jekyll-smart-reading-time
- jekyll-better-related
- jekyll-opengraph-image
- jekyll-social-share
- jekyll-webmentions-static
- jekyll-keepachangelog
- jekyll-toc-generator