### PR TITLE
Add jekyll-timeline and jekyll-before-after

### DIFF
--- a/_plugins/jekyll-before-after.md
+++ b/_plugins/jekyll-before-after.md
@@ -1,0 +1,8 @@
+---
+title: jekyll-before-after
+description: >
+  Liquid tag for drag-to-reveal image comparison sliders with horizontal and vertical orientations, keyboard and pointer support, and no JavaScript dependencies.
+author: jchance
+git: git@github.com:jchance/jekyll-before-after.git
+repository: https://github.com/jchance/jekyll-before-after
+---

--- a/_plugins/jekyll-timeline.md
+++ b/_plugins/jekyll-timeline.md
@@ -1,0 +1,8 @@
+---
+title: jekyll-timeline
+description: >
+  Liquid block tag for rendering styled vertical timelines with icon support, flexible date formatting, and per-event customization.
+author: jchance
+git: git@github.com:jchance/jekyll-timeline.git
+repository: https://github.com/jchance/jekyll-timeline
+---


### PR DESCRIPTION
Adds two new Jekyll plugins to the directory.

- jekyll-timeline: Liquid block tag for rendering styled vertical timelines with icon support, flexible date formatting, and per-event customization.
- jekyll-before-after: Liquid tag for drag-to-reveal image comparison sliders with horizontal and vertical orientations, keyboard and pointer support, and no JavaScript dependencies.